### PR TITLE
fix: (AT) pass dial value as AT serviceCode

### DIFF
--- a/dialoguss.go
+++ b/dialoguss.go
@@ -88,6 +88,7 @@ type Session struct {
 	PhoneNumber string  `yaml:"phoneNumber"`
 	Description string  `yaml:"description"`
 	Steps       []*Step `yaml:"steps"`
+	serviceCode string
 	url         string
 	client      *http.Client
 	ApiType     string
@@ -116,6 +117,7 @@ func NewInteractiveSession(d DialogussConfig) *Session {
 		PhoneNumber: d.PhoneNumber,
 		Description: "Interactive Session",
 		Steps:       nil,
+		serviceCode: d.Dial,
 		url:         d.URL,
 		client:      &http.Client{},
 		ApiType:     apiType,

--- a/dialoguss_africastalking.go
+++ b/dialoguss_africastalking.go
@@ -20,6 +20,7 @@ func (s *Step) ExecuteAsAfricasTalking(session *Session) (string, error) {
 	data := url.Values{}
 	data.Set("sessionId", session.ID)
 	data.Set("phoneNumber", session.PhoneNumber)
+	data.Set("serviceCode", session.serviceCode)
 	var text = s.Text
 	if &text == nil {
 		return "", errors.New("Input Text cannot be nil")


### PR DESCRIPTION
The `serviceCode` field can be used as a form of validation/to distinguish source teleco when writing AT USSD servers. This PR optionally sends the `serviceCode`  to AT passed from the `yaml:dial` config.

Tested on one of my servers which uses said `serviceCode` validation

docs: https://developers.africastalking.com/docs/ussd/handle_sessions

