### PR TITLE
Add timeount configuration ⏰

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+.vscode/
+dialoguss


### PR DESCRIPTION
- Add `timeout` property to the configuration to allow loading timeout value from configuration files. Use case is when debugging and need more time to step through code without losing the connection.