### PR TITLE
Refactor to support to use as library

### DIFF
--- a/pkg/africastalking/africastalking.go
+++ b/pkg/africastalking/africastalking.go
@@ -1,4 +1,4 @@
-package main
+package africastalking
 
 import (
 	"errors"
@@ -7,7 +7,13 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+
+	"github.com/nndi-oss/dialoguss/pkg/core"
 )
+
+type AfricasTalkingRouteStep struct {
+	*core.Step
+}
 
 var (
 	reUssdCon = regexp.MustCompile(`^CON\s?`)
@@ -16,11 +22,11 @@ var (
 
 /// Executes a step as an AfricasTalking API request
 /// May return an empty string ("") upon failure
-func (s *Step) ExecuteAsAfricasTalking(session *Session) (string, error) {
+func (s *AfricasTalkingRouteStep) ExecuteAsAfricasTalking(session *core.Session) (string, error) {
 	data := url.Values{}
 	data.Set("sessionId", session.ID)
 	data.Set("phoneNumber", session.PhoneNumber)
-	data.Set("serviceCode", session.serviceCode)
+	data.Set("serviceCode", session.ServiceCode)
 	var text = s.Text
 	if &text == nil {
 		return "", errors.New("Input Text cannot be nil")
@@ -28,9 +34,9 @@ func (s *Step) ExecuteAsAfricasTalking(session *Session) (string, error) {
 	data.Set("text", text)  // TODO(zikani): concat the input
 	data.Set("channel", "") // TODO: Get the channel
 
-	res, err := session.client.PostForm(session.url, data)
+	res, err := session.Client.PostForm(session.Url, data)
 	if err != nil {
-		log.Printf("Failed to send request to %s", session.url)
+		log.Printf("Failed to send request to %s", session.Url)
 		return "", err
 	}
 
@@ -43,10 +49,10 @@ func (s *Step) ExecuteAsAfricasTalking(session *Session) (string, error) {
 	responseText := string(b)
 	if reUssdCon.MatchString(responseText) {
 		responseText = strings.Replace(responseText, "CON ", "", 1)
-		s.isLast = false
+		s.IsLast = false
 	} else if reUssdEnd.MatchString(responseText) {
 		responseText = strings.Replace(responseText, "END ", "", 1)
-		s.isLast = true
+		s.IsLast = true
 	}
 
 	return responseText, nil

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -1,0 +1,44 @@
+package core
+
+import (
+	"net/http"
+	"time"
+)
+
+/// Dialoguss
+///
+/// Dialoguss is an application that can have one or more pseudo-ussd sessions
+type Dialoguss struct {
+	IsInteractive bool
+	File          string
+	Config        DialogussConfig
+}
+
+
+type Step struct {
+	StepNo int
+	IsLast bool
+	IsDial bool
+	Text   string `yaml:"userInput"`
+	Expect string `yaml:"expect"`
+}
+
+type Session struct {
+	ID          string  `yaml:"id"`
+	PhoneNumber string  `yaml:"phoneNumber"`
+	Description string  `yaml:"description"`
+	Steps       []*Step `yaml:"steps"`
+	ServiceCode string
+	Url         string
+	Client      *http.Client
+	ApiType     string
+	Timeout     time.Duration
+}
+
+type DialogussConfig struct {
+	URL         string    `yaml:"url"`
+	Dial        string    `yaml:"dial"`
+	PhoneNumber string    `yaml:"phoneNumber"`
+	Sessions    []Session `yaml:"sessions"`
+	Timeout     int       `yaml:"timeout"`
+}

--- a/pkg/trueroute/truroute.go
+++ b/pkg/trueroute/truroute.go
@@ -1,4 +1,4 @@
-package main
+package trueroute
 
 import (
 	"bytes"
@@ -6,7 +6,13 @@ import (
 	"errors"
 	"io/ioutil"
 	"log"
+
+	"github.com/nndi-oss/dialoguss/pkg/core"
 )
+
+type TrueRouteStep struct {
+	*core.Step
+}
 
 const (
 	TrurouteCodeInitial  = 1
@@ -53,7 +59,7 @@ func (t *TruRouteResponse) GetText() string {
 
 /// Executes a step and returns the result of the request
 /// May return an empty string ("") upon failure
-func (s *Step) ExecuteAsTruRouteRequest(session *Session) (string, error) {
+func (s *TrueRouteStep) ExecuteAsTruRouteRequest(session *core.Session) (string, error) {
 	var text = s.Text
 	if &text == nil {
 		return "", errors.New("Input Text cannot be nil")
@@ -66,16 +72,16 @@ func (s *Step) ExecuteAsTruRouteRequest(session *Session) (string, error) {
 	req.Session = session.ID
 	req.Msisdn = session.PhoneNumber
 
-	if s.isDial {
+	if s.IsDial {
 		req.Type = TrurouteCodeInitial
 		req.Message = "0"
 	}
 
 	marshalledXml, err := xml.Marshal(req)
 
-	res, err := session.client.Post(session.url, "text/xml", bytes.NewReader(marshalledXml))
+	res, err := session.Client.Post(session.Url, "text/xml", bytes.NewReader(marshalledXml))
 	if err != nil || res.StatusCode != 200 {
-		log.Printf("Failed to send request %s to %s", marshalledXml, session.url)
+		log.Printf("Failed to send request %s to %s", marshalledXml, session.Url)
 		return "", err
 	}
 
@@ -91,7 +97,7 @@ func (s *Step) ExecuteAsTruRouteRequest(session *Session) (string, error) {
 		return "", err
 	}
 
-	s.isLast = trurouteResponse.isRelease()
+	s.IsLast = trurouteResponse.isRelease()
 
 	return trurouteResponse.GetText(), nil
 }


### PR DESCRIPTION
Refactored some of the core functionalities into their own separate packages so that this utility can be used as a library. 
This solves the issue where Golang cannot import the package because it has the **main** package.
Moved non-cli functionality out of the main package.

Note: I tested with a africas talking compliant API the default **dialoguss.yml** passed. 