### PR TITLE
Add referencing steps as components

### DIFF
--- a/cmd/dialoguss_test.go
+++ b/cmd/dialoguss_test.go
@@ -1,0 +1,272 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nndi-oss/dialoguss/pkg/core"
+)
+
+func FillComponentStore(store *ComponentStore, namespace string, components ...core.Component) {
+	if _, ok := (*store)[namespace]; !ok {
+		container := make(map[string]string)
+		(*store)[namespace] = container
+	}
+
+	for _, component := range components {
+		(*store)[namespace][component.ID] = component.Expect
+	}
+}
+
+func TestResolveStepExpectedValue(t *testing.T) {
+	t.Run("Step.Expect is used when no ComponentID is Provided", func(*testing.T) {
+		want := "Hello"
+
+		session := core.Session{ID: "foo"}
+		step := core.Step{StepNo: 1, Expect: want}
+		store := make(ComponentStore)
+		FillComponentStore(&store, "default", core.Component{ID: "bar"})
+
+		returned, _ := ResolveStepExpectedValue(&session, &step, &store)
+		if returned != want {
+			t.Fatalf(`ResolveStepExpectedValue == "%s", want "%s"`, returned, want)
+		}
+	})
+
+	t.Run("Step.Expect overrides Component.Expect", func(*testing.T) {
+		want := "Testicles of Narnia"
+
+		session := core.Session{ID: "foo"}
+		step := core.Step{StepNo: 1, Expect: want, ComponentID: "default/bar"}
+		store := make(ComponentStore)
+		FillComponentStore(&store, "default", core.Component{ID: "bar"})
+
+		returned, _ := ResolveStepExpectedValue(&session, &step, &store)
+		if returned != want {
+			t.Fatalf(`ResolveStepExpectedValue == "%s", want "%s"`, returned, want)
+		}
+	})
+
+	t.Run("Component.Expect is used when Step.Expect is not provided", func(t *testing.T) {
+		want := "Thou shalt not test the lord thy God"
+
+		session := core.Session{ID: "foo"}
+		step := core.Step{StepNo: 1, Expect: "", ComponentID: "default/bar"}
+		store := make(ComponentStore)
+		FillComponentStore(&store, "default", core.Component{ID: "bar", Expect: want})
+
+		returned, _ := ResolveStepExpectedValue(&session, &step, &store)
+		if returned != want {
+			t.Fatalf(`ResolveStepExpectedValue == "%s", want "%s"`, returned, want)
+		}
+
+	})
+
+	t.Run("Errors when a non existent Step.ComponentID", func(*testing.T) {
+		session := core.Session{ID: "foo"}
+		step := core.Step{StepNo: 1, Expect: "", ComponentID: "foo/bar"}
+		store := make(ComponentStore)
+		FillComponentStore(&store, "foo", core.Component{ID: "foo", Expect: "Nada!"})
+
+		_, err := ResolveStepExpectedValue(&session, &step, &store)
+		if err == nil {
+			t.Fatalf("ResolveStepExpectedValue did not error")
+		}
+	})
+
+	t.Run("Uses default namespace when Step.ComponentID is not namespaced", func(*testing.T) {
+		want := "My patience is being tested here"
+
+		session := core.Session{ID: "foobbar"}
+		step := core.Step{StepNo: 1, Expect: "", ComponentID: "bar"}
+		store := make(ComponentStore)
+		FillComponentStore(&store, "default", core.Component{ID: "bar", Expect: want})
+
+		returned, _ := ResolveStepExpectedValue(&session, &step, &store)
+		if returned != want {
+			t.Fatalf(`ResolveStepExpectedValue == "%s", want "%s"`, returned, want)
+		}
+	})
+}
+
+func CreateTestDialoguss(url string, steps []*core.Step, components []*core.Component) *Dialoguss {
+	return &Dialoguss{
+		IsInteractive: false,
+		File:          "/dev/null",
+		Config: core.DialogussConfig{
+			URL:         url,
+			Dial:        "*6969#",
+			PhoneNumber: "0888800900",
+			Sessions: []core.Session{
+				{
+					ID:          "c-session",
+					PhoneNumber: "0888800900",
+					Description: "It's the gat damn session",
+					Steps:       steps,
+					Url:         url,
+					Client:      &http.Client{},
+					ApiType:     ApiTypeAfricastalking,
+					Timeout:     1000,
+				},
+			},
+			Components: []core.ComponentNamespace{
+				{
+					Namespace: "default",
+					Items:     components,
+				},
+			},
+		},
+	}
+}
+
+func CreateMockHttpServer(status int, responses ...string) *httptest.Server {
+	responseNo := 0
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if responseNo >= len(responses) {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("You are asking too many questions!"))
+			return
+		}
+
+		anchor := "CON"
+		if responseNo < len(responses)-1 {
+			anchor = "END"
+		}
+
+		response := fmt.Sprintf("%s %s", anchor, responses[responseNo])
+
+		w.WriteHeader(status)
+		w.Write([]byte(response))
+		responseNo += 1
+	}))
+}
+
+func TestRunAutomatedSession(t *testing.T) {
+	t.Run("Passes steps with matched expectations", func(*testing.T) {
+		server := CreateMockHttpServer(http.StatusOK, "Welcome", "Hello")
+		defer server.Close()
+
+		dialoguss := CreateTestDialoguss(
+			server.URL,
+			[]*core.Step{
+				{
+					Expect: "Welcome",
+				},
+				{
+					Text:   "1",
+					Expect: "Hello",
+				},
+			},
+			[]*core.Component{},
+		)
+		failed, err := dialoguss.RunAutomatedSessions()
+		if err != nil {
+			t.Fatalf("Session run failed: %v", err)
+		}
+
+		if failed != 0 {
+			t.Fatalf("Unexpected number of failed sessions, expected: 0, got: %d", failed)
+		}
+	})
+
+	t.Run("Fails steps with unmatched expectations", func(*testing.T) {
+		server := CreateMockHttpServer(http.StatusOK, "Welcome", "Hello")
+		defer server.Close()
+
+		dialoguss := CreateTestDialoguss(
+			server.URL,
+			[]*core.Step{
+				{
+					Expect: "Mwalandilidwa",
+				},
+				{
+					Expect: "Hello",
+					Text:   "2",
+				},
+			},
+			[]*core.Component{},
+		)
+		failed, err := dialoguss.RunAutomatedSessions()
+		if err != nil {
+			t.Fatalf("Session run failed: %v", err)
+		}
+
+		if failed != 1 {
+			t.Fatalf("Unexpected number of failed sessions, expected: 1, got: %d", failed)
+		}
+	})
+
+	t.Run("Passes steps with matching component expectations", func(*testing.T) {
+		server := CreateMockHttpServer(http.StatusOK, "Welcome", "Hello")
+		defer server.Close()
+
+		dialoguss := CreateTestDialoguss(
+			server.URL,
+			[]*core.Step{
+				{
+					ComponentID: "default.splash",
+				},
+				{
+					ComponentID: "home",
+					Expect:      "Hello",
+				},
+			},
+			[]*core.Component{
+				{
+					ID:     "splash",
+					Expect: "Welcome",
+				},
+				{
+					ID:     "home",
+					Expect: "Hello",
+				},
+			},
+		)
+		failed, err := dialoguss.RunAutomatedSessions()
+		if err != nil {
+			t.Fatalf("Session run failed: %v", err)
+		}
+
+		if failed != 0 {
+			t.Fatalf("Unexpected number of failed sessions, expected: 0, got: %d", failed)
+		}
+	})
+
+	t.Run("Fails steps with non-matching component expectations", func(t *testing.T) {
+		server := CreateMockHttpServer(http.StatusOK, "Welcome", "Hello")
+		defer server.Close()
+
+		dialoguss := CreateTestDialoguss(
+			server.URL,
+			[]*core.Step{
+				{
+					ComponentID: "default.splash",
+				},
+				{
+					ComponentID: "home",
+					Expect:      "Hello",
+				},
+			},
+			[]*core.Component{
+				{
+					ID:     "splash",
+					Expect: "Mwalandilidwa",
+				},
+				{
+					ID:     "home",
+					Expect: "Hello",
+				},
+			},
+		)
+		failed, err := dialoguss.RunAutomatedSessions()
+		if err != nil {
+			t.Fatalf("Session run failed: %v", err)
+		}
+
+		if failed != 1 {
+			t.Fatalf("Unexpected number of failed sessions, expected: 1, got: %d", failed)
+		}
+	})
+}

--- a/cmd/dialoguss_test.go
+++ b/cmd/dialoguss_test.go
@@ -36,7 +36,7 @@ func TestResolveStepExpectedValue(t *testing.T) {
 	})
 
 	t.Run("Step.Expect overrides Component.Expect", func(*testing.T) {
-		want := "Testicles of Narnia"
+		want := "Chronicles of Narnia"
 
 		session := core.Session{ID: "foo"}
 		step := core.Step{StepNo: 1, Expect: want, ComponentID: "default/bar"}

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -13,11 +13,22 @@ type Dialoguss struct {
 }
 
 type Step struct {
-	StepNo int
-	IsLast bool
-	IsDial bool
-	Text   string `yaml:"userInput"`
+	StepNo      int
+	IsLast      bool
+	IsDial      bool
+	Text        string `yaml:"userInput"`
+	Expect      string `yaml:"expect"`
+	ComponentID string `yaml:"componentId"`
+}
+
+type Component struct {
+	ID     string `yaml:"id"`
 	Expect string `yaml:"expect"`
+}
+
+type ComponentNamespace struct {
+	Namespace string       `yaml:"namespace"`
+	Items     []*Component `yaml:"component"`
 }
 
 type Session struct {
@@ -33,9 +44,10 @@ type Session struct {
 }
 
 type DialogussConfig struct {
-	URL         string    `yaml:"url"`
-	Dial        string    `yaml:"dial"`
-	PhoneNumber string    `yaml:"phoneNumber"`
-	Sessions    []Session `yaml:"sessions"`
-	Timeout     int       `yaml:"timeout"`
+	URL         string               `yaml:"url"`
+	Dial        string               `yaml:"dial"`
+	PhoneNumber string               `yaml:"phoneNumber"`
+	Sessions    []Session            `yaml:"sessions"`
+	Components  []ComponentNamespace `yaml:"components"`
+	Timeout     int                  `yaml:"timeout"`
 }


### PR DESCRIPTION
1. A new field named `components` is introduced
2. The components field takes a list of namespaces
3. Each namespace takes a list of components
4. Steps can reference components through a `componentId`

A sample configuration below:

```yaml
url: http://localhost:7654
dial: "*1234*1234#"
phoneNumber: 265888123456
sessions:
  - id: check-balance
    phoneNumber: 265888123456
    description: "Should return a balance of 500 for Zikani"
    steps:
      # Component IDs can be namespaced (e.g. default.login),
      # "default" namespace can be omitted as below
      - componentId: "login"
      - userInput: "Zikani"
        componentId: "default.home"
      - userInput: "2"
        componentId: "check-balance.display-balance"
  - id: update-account-name:
    steps:
        - componentId: "login"
        - userInput: "Zikani"
          componentId: "home"
        - userInput: "2"
          componentId: "account-detail.home"
        - userInput: 1
          expect: Enter your new name:
  - id: request-account-statement:
    steps:
        - componentId: "login"
        - userInput: "Zikani"
          componentId: "home"
        - userInput: "2"
          componentId: "account-detail.home"
        - userInput: 2
          expect: "Your statement is being processed!"
components:
  - namespace: default
    items:
      - id: login
        expect: "What is your name?"
      - id: home
        expect: |-
          Welcome, Zikani
          Choose an item:
          1. Account detail
          2. Balance
          3. Something else
          # Exit
  - namespace: check-balance
    items:
      - id: display-balance
        expect: "You are broke!"
  - namespace: account-detail
    items:
      - id: home
        expect: |-
          1. Change name
          2. Statement
```

Partially addresses #8 